### PR TITLE
feat: add prometheus rule & grafana dashboards files

### DIFF
--- a/springboot-micrometer-hol/docker-compose/docker-compose.yaml
+++ b/springboot-micrometer-hol/docker-compose/docker-compose.yaml
@@ -18,6 +18,7 @@ services:
     volumes:
       - hands-on-prometheus-data:/prometheus
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./prometheus/rules:/etc/prometheus/rules
     restart: unless-stopped
     networks:
       - hands-on-network

--- a/springboot-micrometer-hol/docker-compose/docker-compose.yaml
+++ b/springboot-micrometer-hol/docker-compose/docker-compose.yaml
@@ -33,6 +33,7 @@ services:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
       - hands-on-grafana-data:/var/lib/grafana
+      - ./grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards
     depends_on:
       - prometheus
     restart: unless-stopped

--- a/springboot-micrometer-hol/docker-compose/grafana/provisioning/dashboards/dashboard.yaml
+++ b/springboot-micrometer-hol/docker-compose/grafana/provisioning/dashboards/dashboard.yaml
@@ -1,0 +1,9 @@
+apiVersion: 1
+providers:
+  - name: 'default'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/springboot-micrometer-hol/docker-compose/grafana/provisioning/dashboards/json/grafana-dashboard1.json
+++ b/springboot-micrometer-hol/docker-compose/grafana/provisioning/dashboards/json/grafana-dashboard1.json
@@ -1,0 +1,125 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": null,
+  "iteration": 1693560000000,
+  "links": [],
+  "panels": [
+    {
+      "title": "HTTP Request Duration",
+      "type": "graph",
+      "targets": [
+        {
+          "expr": "rate(http_request_duration_seconds_sum[1m]) / rate(http_request_duration_seconds_count[1m])",
+          "legendFormat": "{{method}} {{uri}}",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "Active HTTP Requests",
+      "type": "gauge",
+      "targets": [
+        {
+          "expr": "sum(http_server_requests_active_seconds_count)",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "FooService Method Calls",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "sum by (method) (foo_service_calls)",
+          "refId": "A"
+        }
+      ]
+    },
+    {
+      "title": "FooService Method Duration Heatmap",
+      "type": "heatmap",
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum(rate(foo_service_methods_bucket[1m])) by (le, method))",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    },
+    {
+      "title": "JVM Memory Usage",
+      "type": "stat",
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes / jvm_memory_max_bytes * 100",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "unit": "percent"
+    },
+    {
+      "title": "JVM Threads Live",
+      "type": "table",
+      "targets": [
+        {
+          "expr": "jvm_threads_live",
+          "refId": "A"
+        }
+      ],
+      "gridPos": {
+        "h": 12,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      }
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 36,
+  "style": "dark",
+  "tags": [
+    "springboot",
+    "micrometer",
+    "prometheus"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "SpringBoot Micrometer Monitoring",
+  "uid": "springboot-micrometer-dashboard",
+  "version": 1
+}

--- a/springboot-micrometer-hol/docker-compose/prometheus/prometheus.yml
+++ b/springboot-micrometer-hol/docker-compose/prometheus/prometheus.yml
@@ -18,3 +18,6 @@ scrape_configs:
       - source_labels: [__name__]
         regex: 'custom_.*'
         action: keep
+
+rule_files:
+  - "/etc/prometheus/rules/*.yml"

--- a/springboot-micrometer-hol/docker-compose/prometheus/rules/prometheus-rules.yml
+++ b/springboot-micrometer-hol/docker-compose/prometheus/rules/prometheus-rules.yml
@@ -1,0 +1,66 @@
+groups:
+  - name: actuator_metrics
+    interval: 30s
+    rules:
+      # ----------------------------
+      # Actuator Native Metrics
+      # ----------------------------
+      - record: http_server_requests_total
+        expr: sum by (method, status, uri) (http_server_requests_seconds_count)
+        labels:
+          source: actuator
+      - record: http_server_request_duration_seconds_avg
+        expr: sum by (method, status, uri) (http_server_requests_seconds_sum)
+          / sum by (method, status, uri) (http_server_requests_seconds_count)
+        labels:
+          source: actuator
+  - name: aop_service_layer_metrics
+    interval: 30s
+    rules:
+      # ----------------------------
+      # Customized AOP Layer Metrics
+      # ----------------------------
+      - record: foo_service_method_duration_avg
+        expr: sum by (method) (foo_service_methods_sum)
+          / sum by (method) (foo_service_methods_count)
+        labels:
+          source: aop
+
+      - record: foo_service_methods_total
+        expr: sum by (method) (foo_service_calls)
+        labels:
+          source: aop
+
+      # Alerts
+      - alert: FooServiceMethodSlow
+        expr: foo_service_method_duration_avg > 1
+        for: 1m
+        labels:
+          serverity: warning
+        annotations:
+          summary: "FooService method avg duration > 1s"
+
+  - name: interceptor_servlet_layer_metrics
+    interval: 30s
+    rules:
+      # ---------------------------------------------
+      # Customized Interceptor Servlet Layer Metrics
+      # ---------------------------------------------
+      - record: http_request_duration_avg
+        expr: sum by (method, uri) (http_request_duration_seconds_sum)
+          / sum by (method, uri) (http_request_duration_seconds_count)
+        labels:
+          source: interceptor
+
+      - record: http_request_total
+        expr: sum by (method, uri) (http_request_duration_seconds_count)
+        labels:
+          source: interceptor
+
+      - alert: HighHttpRequestLatency
+        expr: http_request_duration_avg > 1
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: "HTTP request avg duration > 1s"


### PR DESCRIPTION
In this commit, we add 
- rule YAML file for organizing metrics in categories and second-aggregate calculation 
- Grafana JSON files based on rules defined in `prometheus-rules.yml` 